### PR TITLE
Finishes implementation of the basic DIMM CSC functionality.

### DIFF
--- a/python/lsst/ts/dimm/config/config.yaml
+++ b/python/lsst/ts/dimm/config/config.yaml
@@ -30,3 +30,8 @@ setting:
         min: 1
         max: 3
         std: 0.1  # random deviation from actual value
+  soar:
+    type: 'soar'
+    configuration:
+      uri: 'mysql://becs:becs_sql@139.229.13.222/pachon'
+      check_interval: 180.

--- a/python/lsst/ts/dimm/controllers/__init__.py
+++ b/python/lsst/ts/dimm/controllers/__init__.py
@@ -20,3 +20,4 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from .sim_dimm import *
+from .soar_dimm import *

--- a/python/lsst/ts/dimm/controllers/base_dimm.py
+++ b/python/lsst/ts/dimm/controllers/base_dimm.py
@@ -1,4 +1,6 @@
 
+import abc
+
 __all__ = ['BaseDIMM', 'DIMMStatus']
 
 DIMMStatus = {'NOTSET': 0,
@@ -8,12 +10,12 @@ DIMMStatus = {'NOTSET': 0,
               }
 
 
-class BaseDIMM:
+class BaseDIMM(abc.ABC):
     """Base class for DIMM controllers.
 
-This class defines the minimum set of methods required to operate a DIMM in the context of the
-LSST CSC environment. When developing a controller for a CSC, one should subclass this method and
-overwrite the methods as required to setup and operate the DIMM.
+    This class defines the minimum set of methods required to operate a DIMM in the context of the
+    LSST CSC environment. When developing a controller for a CSC, one should subclass this method and
+    overwrite the methods as required to setup and operate the DIMM.
     """
     def __init__(self):
         self.status = {'status': DIMMStatus['NOTSET'],
@@ -59,3 +61,14 @@ overwrite the methods as required to setup and operate the DIMM.
 
         """
         return self.status
+
+    @abc.abstractmethod
+    async def get_measurement(self):
+        """Coroutine to wait and return new seeing measurements.
+
+        Returns
+        -------
+        measurement : dict
+            A dictionary with the same values of the dimmMeasurement topic SAL Event.
+        """
+        raise NotImplementedError()

--- a/python/lsst/ts/dimm/controllers/soar_dimm.py
+++ b/python/lsst/ts/dimm/controllers/soar_dimm.py
@@ -19,7 +19,10 @@ class SOARDIMM(BaseDIMM):
     def __init__(self):
         super().__init__()
 
-        warnings.warn("This class is still under development and will not work as expected.")
+        warnings.warn("This class is still under development and will not work as expected. If instantiated, "
+                      "it will start a coroutine that is responsible for grabbing the DIMM data from a "
+                      "sql database but the loop won't do anything. The CSC will look like is running"
+                      "but it will not grab or publish any data.")
 
         self.uri = "mysql://user:password@host/database/"
         """The uri address to connect to the DIMM database."""

--- a/python/lsst/ts/dimm/controllers/soar_dimm.py
+++ b/python/lsst/ts/dimm/controllers/soar_dimm.py
@@ -1,0 +1,99 @@
+
+import asyncio
+import sqlalchemy
+import warnings
+
+from .base_dimm import BaseDIMM, DIMMStatus
+
+
+__all__ = ['SOARDIMM']
+
+
+class SOARDIMM(BaseDIMM):
+    """This controller provides an interface with the SOAR telescope DIMM. This will connect to their sql database
+    and publish the data to LSST middleware.
+
+    This controller class is still under development.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+        warnings.warn("This class is still under development and will not work as expected.")
+
+        self.uri = "mysql://user:password@host/database/"
+        """The uri address to connect to the DIMM database."""
+        self.table = 'Pachon_seeing'
+        """Name of the table to query"""
+        self.check_interval = 180.
+        """The interval to wait before checking the database for new data."""
+
+        self.engine = None
+
+        # self.db_query = "select * from {} order by ut desc limit 1"
+
+        self.measurement_loop = None
+        self.measurement_start = None
+        self.measurement_queue = []
+        self.last_measurement = None
+
+    def setup(self, uri, check_interval):
+        """Setup SOARDIMM.
+
+        Parameters
+        ----------
+        uri: str
+            The uri address to connect to the dimm.
+        check_interval: float
+            Time to wait before checking the database for new data (in seconds).
+        """
+
+        self.uri = uri
+        self.check_interval = check_interval
+        self.engine = sqlalchemy.create_engine(self.uri, pool_recycle=3600)
+
+    def start(self):
+        """Start DIMM. Overwrites method from base class."""
+        self.status['status'] = DIMMStatus['RUNNING']
+        self.measurement_loop = asyncio.ensure_future(self.check_db_loop())
+
+    def stop(self):
+        """Stop DIMM. Overwrites method from base class."""
+        self.measurement_loop.cancel()
+        self.status['status'] = DIMMStatus['INITIALIZED']
+
+    async def check_db_loop(self):
+        """Coroutine to check the database for new measurements.
+        """
+
+        while True:
+
+            # self.measurement_queue.append(measurement)
+
+            await asyncio.sleep(self.check_interval)
+
+    async def get_measurement(self):
+        """Coroutine to wait and return new seeing measurements.
+
+        Returns
+        -------
+        measurement : dict
+            A dictionary with the same values of the dimmMeasurement topic SAL Event.
+        """
+
+        while True:
+            if len(self.measurement_queue) > 0:
+                return self.measurement_queue.pop(0)
+            else:
+                await asyncio.sleep(1)
+
+    def _get_mysql(self):
+        """Connect to the CTIO database and get the seeing data."""
+
+        connection = self.engine.connect()
+
+        result = connection.execute(self.db_query)
+        row = result.fetchone()
+
+        connection.close()
+        return row

--- a/python/lsst/ts/dimm/dimm_csc.py
+++ b/python/lsst/ts/dimm/dimm_csc.py
@@ -11,7 +11,17 @@ from .model import Model
 __all__ = ['DIMMCSC']
 
 SEEING_LOOP_DONE = 101
+""" Seeing loop done (`int`).
+
+This error code is published in `SALPY_DIMM.DIMM_logevent_errorCodeC` if the coroutine that
+gets new seeing data from the controller finishes while the CSC is in enable state.
+"""
 TELEMETRY_LOOP_DONE = 102
+""" Telemetry loop done (`int`).
+
+This error code is published in `SALPY_DIMM.DIMM_logevent_errorCodeC` if the coroutine that
+monitors the health and status of the DIMM finishes while the CSC is in enable state.
+"""
 
 
 class DIMMCSC(base_csc.BaseCsc):
@@ -33,9 +43,6 @@ class DIMMCSC(base_csc.BaseCsc):
         self.model = Model()  # instantiate the model so I can have the settings once the component is up
 
         super().__init__(SALPY_DIMM, index)
-
-        # set/publish summaryState
-        self.summary_state = base_csc.State.STANDBY
 
         # publish settingVersions
         settingVersions_topic = self.evt_settingVersions.DataType()

--- a/python/lsst/ts/dimm/model.py
+++ b/python/lsst/ts/dimm/model.py
@@ -7,7 +7,8 @@ from lsst.ts.dimm import controllers
 
 __all__ = ['Model']
 
-available_controllers = {'sim': controllers.SimDIMM}
+available_controllers = {'sim': controllers.SimDIMM,
+                         'soar': controllers.SOARDIMM}
 
 
 class Model:

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -73,7 +73,7 @@ class TestDIMMCSC(unittest.TestCase):
 
             # send start; new state is DISABLED
             cmd_attr = getattr(harness.remote, f"cmd_start")
-            state_coro = harness.remote.evt_summaryState.next(timeout=1.)
+            state_coro = harness.remote.evt_summaryState.next(flush=True, timeout=1.)
             start_topic = cmd_attr.DataType()
             start_topic.settingsToApply = 'simulation'  # user simulation setting.
             id_ack = await cmd_attr.start(start_topic, timeout=120)  # this one can take longer to execute
@@ -82,9 +82,6 @@ class TestDIMMCSC(unittest.TestCase):
             self.assertEqual(id_ack.ack.error, 0)
             self.assertEqual(harness.csc.summary_state, salobj.State.DISABLED)
             self.assertEqual(state.summaryState, salobj.State.DISABLED)
-
-            # TODO: There are two events issued when starting the scheduler; appliedSettingsMatchStart and
-            # settingsApplied. Check that they are received.
 
             for bad_command in commands:
                 if bad_command in ("enable", "standby"):
@@ -96,7 +93,7 @@ class TestDIMMCSC(unittest.TestCase):
 
             # send enable; new state is ENABLED
             cmd_attr = getattr(harness.remote, f"cmd_enable")
-            state_coro = harness.remote.evt_summaryState.next(timeout=1.)
+            state_coro = harness.remote.evt_summaryState.next(flush=True, timeout=1.)
             id_ack = await cmd_attr.start(cmd_attr.DataType(), timeout=1.)
             state = await state_coro
             self.assertEqual(id_ack.ack.ack, harness.remote.salinfo.lib.SAL__CMD_COMPLETE)
@@ -114,7 +111,7 @@ class TestDIMMCSC(unittest.TestCase):
 
             # check that received telemetry topic from dimm
             try:
-                await harness.remote.tel_status.next(timeout=salobj.base_csc.HEARTBEAT_INTERVAL*5)
+                await harness.remote.tel_status.next(flush=True, timeout=salobj.base_csc.HEARTBEAT_INTERVAL*5)
             except asyncio.TimeoutError:
                 self.assertTrue(False, 'No status published by DIMM')
 


### PR DESCRIPTION
Adds soar_dimm a controller interface to grab data from the SOAR DIMM database. The controller is still under development, we will access whether or not to finish it in the future. I also need to get access to the database on the summit. The data I have access to at this time is outdated.