### PR TITLE
DM-49229 Implement setAmebaMode in DIMM

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -4,6 +4,12 @@
 Version History
 ===============
 
+v0.9.4
+------
+
+* Implemented the `setAmebaMode` CSC command.
+* Implemented the `ameba` telemetry topic.
+
 v0.9.3
 ------
 

--- a/python/lsst/ts/dimm/controllers/base_dimm.py
+++ b/python/lsst/ts/dimm/controllers/base_dimm.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import abc
+from enum import IntEnum
 
 __all__ = ["BaseDIMM", "DIMMStatus"]
 
@@ -30,6 +31,12 @@ DIMMStatus = {
     "RUNNING": 1 << 2,
     "ERROR": 1 << 3,
 }
+
+
+class AutomationMode(IntEnum):
+    OFF = 0
+    AUTO = 1
+    MANUAL = 2
 
 
 class BaseDIMM(abc.ABC):
@@ -49,6 +56,14 @@ class BaseDIMM(abc.ABC):
             "altitude": 0.0,
             "azimuth": 0.0,
             "hrnum": 0,
+        }
+        self.ameba = {
+            "mode": -1,
+            "state": -1,
+            "sunAltitude": float("nan"),
+            "condition": -1,
+            "startTime": 0,
+            "finishTime": 0,
         }
         self.log = log.getChild(type(self).__name__)
         self.simulate = simulate
@@ -99,6 +114,26 @@ class BaseDIMM(abc.ABC):
 
         """
         return self.status
+
+    async def get_ameba(self):
+        """Return the AMEBA telemetry.
+
+        Returns
+        -------
+        ameba : dict
+            Dictionary with AMEBA status.
+        """
+        return self.ameba
+
+    async def set_automation_mode(self, mode: AutomationMode) -> None:
+        """Sets the DIMM to off (0), automatic (1), or manual (2) operation.
+
+        Parameter
+        ---------
+        mode : AutomationMode
+            Desired DIMM operating mode.
+        """
+        raise NotImplementedError()
 
     @abc.abstractmethod
     async def get_measurement(self):

--- a/python/lsst/ts/dimm/controllers/mock_astelco_dimm.py
+++ b/python/lsst/ts/dimm/controllers/mock_astelco_dimm.py
@@ -233,9 +233,10 @@ class AmebaModule(BaseToplevelModule):
     current = AmebaCurrentSubmodule()
     mode = AmebaMode.AUTO
     state = AmebaState.INACTIVE
-    sun_alt_condition = 0.0
-    start_time = 0.0
-    finish_time = 0.0
+    sun_alt = 45.0
+    condition = 7
+    start_time = 946684768.0  # 2000-01-01T00:00:00
+    finish_time = 946684768.0
     _settable_fields = {"mode"}
 
 
@@ -459,8 +460,6 @@ class MockAstelcoDIMM(tcpip.OneClientServer):
                 self.dimm.strehl_right = random.uniform(*DIMMDataRange.strehl_right)
                 self.dimm.timestamp = time.time()
                 self.auto_measurement_event.set()
-        except asyncio.CancelledError:
-            pass
         except Exception:
             self.log.exception("Automatic loop failed")
         finally:
@@ -643,6 +642,10 @@ class MockAstelcoDIMM(tcpip.OneClientServer):
                 self.auto_loop_task = asyncio.create_task(self.auto_loop())
         else:
             self.auto_loop_task.cancel()
+            try:
+                await self.auto_loop_task
+            except asyncio.CancelledError:
+                pass  # expected result
 
     def get_field(self, varname):
         """Get the value of a field."""

--- a/tests/test_mock_astelco_dimm.py
+++ b/tests/test_mock_astelco_dimm.py
@@ -297,6 +297,7 @@ class MockAstelcoDIMMTestCase(unittest.IsolatedAsyncioTestCase):
         await self.authenticate()
 
         for arg in (
+            "AMEBA.MODE=2",
             'AMEBA.MANUAL.NAME="new name"',
             "AMEBA.MANUAL.RA=1.1;AMEBA.MANUAL.DEC=2.2",
             "AMEBA.MANUAL.BRIGHTNESS=3.3",


### PR DESCRIPTION
This PR turns out to also include implementation of the `ameba` telemetry in the DIMM CSC. I added this so that we could have a good unit test covering the `setAmebaMode` functionality.

I ran into some trouble getting the CSC to clean up after itself properly. As a result, some of the asyncio `CancelledError` handling has been re-arranged.