### PR TITLE
OSW-553: Sets AMEBA mode to OFF, daily at 9am and when the CSC disables.

### DIFF
--- a/python/lsst/ts/dimm/dimm_csc.py
+++ b/python/lsst/ts/dimm/dimm_csc.py
@@ -197,24 +197,29 @@ class DIMMCSC(salobj.ConfigurableCsc):
         await self.controller.unset()
         self.controller = None
 
-    async def end_enable(self, id_data):
-        """End do_enable; called after state changes but before command
-        acknowledged.
+    async def end_start(self, id_data):
+        """End do_start; called after state changes.
 
         This method will call `start` on the controller and start the telemetry
-        and seeing monitoring loops.
+        and seeing monitoring loops. It also starts the
+        turn_dimm_off_in_morning background task.
 
         Parameters
         ----------
         id_data : `CommandIdData`
             Command ID and data
         """
+        await self.cmd_start.ack_in_progress(id_data, timeout=60)
 
         try:
             await self.controller.start()
         except Exception:
             self.log.exception("Failed starting the controller.")
-            await self.fault(code=CONTROLLER_START_FAILED)
+            await self.fault(
+                code=CONTROLLER_START_FAILED,
+                report="Controller start failed.",
+                traceback=traceback.format_exc(),
+            )
             raise RuntimeError(
                 "Failed to start controller. Check configuration and make sure DIMM"
                 "controller is alive and reachable by the CSC."
@@ -228,7 +233,21 @@ class DIMMCSC(salobj.ConfigurableCsc):
                 self.turn_dimm_off_in_morning()
             )
 
-        await super().end_enable(id_data)
+        await super().end_start(id_data)
+
+    async def begin_enable(self, id_data):
+        """Begin do_start; called before state changes.
+
+        This method will set AMEBA mode to AUTO.
+
+        Parameters
+        ----------
+        id_data : `CommandIdData`
+            Command ID and data
+        """
+        await self.cmd_enable.ack_in_progress(id_data, timeout=60)
+        await self.controller.set_automation_mode(AutomationMode.AUTO)
+        await super().begin_enable(id_data)
 
     async def begin_disable(self, id_data):
         """Begin do_disable; called before state changes.
@@ -242,49 +261,11 @@ class DIMMCSC(salobj.ConfigurableCsc):
             Command ID and data
         """
         await self.cmd_disable.ack_in_progress(id_data, timeout=60)
-        self.telemetry_loop_running = False
-        self.seeing_loop_running = False
-
-        self.dimm_off_in_morning_task.cancel()
-        try:
-            await self.dimm_off_in_morning_task
-        except asyncio.CancelledError:
-            pass  # Expected result
 
         # Send command to set automation mode OFF.
         await self.controller.set_automation_mode(AutomationMode.OFF)
 
         await super().begin_disable(id_data)
-
-    async def end_disable(self, id_data):
-        """Transition to from `State.ENABLED` to `State.DISABLED`.
-
-        After switching from enable to disable, wait for telemetry and seeing
-        loop to finish. If they take longer then a timeout to finish, cancel
-        the future.
-
-        Parameters
-        ----------
-        id_data : `CommandIdData`
-            Command ID and data
-        """
-
-        try:
-            await self.wait_loop(self.telemetry_loop_task)
-        except Exception:
-            self.log.exception("Error trying to stop the telemetry loop. Continuing.")
-
-        try:
-            await self.wait_loop(self.seeing_loop_task)
-        except Exception:
-            self.log.exception("Error trying to stop the seeing loop. Continuing.")
-
-        try:
-            await self.controller.stop()
-        except Exception:
-            self.log.exception("Error in controller stop. Continuing...")
-
-        await super().end_disable(id_data)
 
     async def begin_standby(self, id_data):
         """Begin do_standby; called before the state changes.
@@ -296,13 +277,46 @@ class DIMMCSC(salobj.ConfigurableCsc):
         id_data : `CommandIdData`
             Command ID and data
         """
+        await self.cmd_standby.ack_in_progress(id_data, timeout=60)
+
+        # Signal the loops to end.
+        self.telemetry_loop_running = False
+        self.seeing_loop_running = False
+
+        self.dimm_off_in_morning_task.cancel()
+        try:
+            await self.dimm_off_in_morning_task
+        except asyncio.CancelledError:
+            pass  # Expected result
+        except Exception:
+            self.log.exception("Error trying to stop the AMEBA OFF timer. Continuing.")
+
+        # End the telemetry loop
+        try:
+            await self.wait_loop(self.telemetry_loop_task)
+        # Signal the loops to end.
+        except Exception:
+            self.log.exception("Error trying to stop the telemetry loop. Continuing.")
+
+        # End the seeing loop
+        try:
+            await self.wait_loop(self.seeing_loop_task)
+        except Exception:
+            self.log.exception("Error trying to stop the seeing loop. Continuing.")
+
+        # Disconnect the controller
+        try:
+            await self.controller.stop()
+        except Exception:
+            self.log.exception("Error in controller stop. Continuing...")
+
+        # De-allocate the controller
         try:
             await self.unset_controller()
         except Exception:
             self.log.exception("Error unsetting controller. Continuing.")
 
         await super().begin_standby(id_data)
-        await self.cmd_standby.ack_in_progress(id_data, timeout=60)
 
     def prepare_status_telemetry(self, state):
         """Prepare the status telemetry for sending by converting the DIMM

--- a/python/lsst/ts/dimm/dimm_csc.py
+++ b/python/lsst/ts/dimm/dimm_csc.py
@@ -249,6 +249,23 @@ class DIMMCSC(salobj.ConfigurableCsc):
         await self.controller.set_automation_mode(AutomationMode.AUTO)
         await super().begin_enable(id_data)
 
+    async def end_enable(self, id_data):
+        """End do_enable; called after state changes.
+
+        This method will launch the turn_dimm_off_in_morning
+        task, in case it is not already running.
+
+        Parameters
+        ----------
+        id_data : `CommandIdData`
+            Command ID and data
+        """
+        if self.dimm_off_in_morning_task.done():
+            self.dimm_off_in_morning_task = asyncio.create_task(
+                self.turn_dimm_off_in_morning()
+            )
+        await super().end_enable(id_data)
+
     async def begin_disable(self, id_data):
         """Begin do_disable; called before state changes.
 

--- a/python/lsst/ts/dimm/dimm_csc.py
+++ b/python/lsst/ts/dimm/dimm_csc.py
@@ -20,8 +20,10 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import asyncio
+import datetime
 import traceback
 import types
+from zoneinfo import ZoneInfo
 
 from lsst.ts import salobj, utils
 from lsst.ts.dimm import controllers
@@ -133,6 +135,7 @@ class DIMMCSC(salobj.ConfigurableCsc):
 
         self.seeing_loop_running = False
         self.seeing_loop_task = utils.make_done_future()
+        self.dimm_off_in_morning_task = utils.make_done_future()
 
         self.csc_running = True
         self.measurement_validity = None
@@ -220,6 +223,11 @@ class DIMMCSC(salobj.ConfigurableCsc):
         self.telemetry_loop_task = asyncio.create_task(self.telemetry_loop())
         self.seeing_loop_task = asyncio.create_task(self.seeing_loop())
 
+        if self.dimm_off_in_morning_task.done():
+            self.dimm_off_in_morning_task = asyncio.create_task(
+                self.turn_dimm_off_in_morning()
+            )
+
         await super().end_enable(id_data)
 
     async def begin_disable(self, id_data):
@@ -236,6 +244,15 @@ class DIMMCSC(salobj.ConfigurableCsc):
         await self.cmd_disable.ack_in_progress(id_data, timeout=60)
         self.telemetry_loop_running = False
         self.seeing_loop_running = False
+
+        self.dimm_off_in_morning_task.cancel()
+        try:
+            await self.dimm_off_in_morning_task
+        except asyncio.CancelledError:
+            pass  # Expected result
+
+        # Send command to set automation mode OFF.
+        await self.controller.set_automation_mode(AutomationMode.OFF)
 
         await super().begin_disable(id_data)
 
@@ -355,6 +372,33 @@ class DIMMCSC(salobj.ConfigurableCsc):
                 report="Error in telemetry loop.",
                 traceback=traceback.format_exc(),
             )
+
+    async def turn_dimm_off_in_morning(self):
+        """Issues a command daily at 9am to set automation off.
+
+        This feature prevents accidental opening by requiring
+        the observer to manually enable DIMM each day before
+        operating.
+        """
+        tz = ZoneInfo("America/Santiago")
+        time_to_turn_off = 9
+
+        while self.disabled_or_enabled:
+            now = datetime.datetime.now(tz)
+            end_time = datetime.datetime.combine(
+                now.date(), datetime.time(time_to_turn_off, 0), tzinfo=tz
+            )
+            if now >= end_time:
+                end_time += datetime.timedelta(days=1)
+            sleep_time = (end_time - now).total_seconds()
+            await asyncio.sleep(sleep_time)
+
+            # Send the command
+            await self.controller.set_automation_mode(AutomationMode.OFF)
+
+            # Make sure we aren't going to get a sleep of zero on the
+            # next run through the loop.
+            await asyncio.sleep(10)
 
     async def seeing_loop(self):
         """Seeing loop coroutine. This method is responsible for getting new
@@ -540,13 +584,11 @@ class DIMMCSC(salobj.ConfigurableCsc):
         """
 
         # wait for telemetry loop to die or kill it if timeout
-        timeout = True
         for i in range(self.loop_die_timeout):
             if loop.done():
-                timeout = False
                 break
             await asyncio.sleep(self.heartbeat_interval)
-        if timeout:
+        else:
             loop.cancel()
 
         try:
@@ -568,5 +610,12 @@ class DIMMCSC(salobj.ConfigurableCsc):
 
         self.csc_running = False
         await self.wait_loop(self.health_monitor_loop_task)
+
+        # Cancel and await the morning task
+        self.dimm_off_in_morning_task.cancel()
+        try:
+            await self.dimm_off_in_morning_task
+        except asyncio.CancelledError:
+            pass  # Expected result
 
         await super().close(exception=exception, cancel_start=cancel_start)


### PR DESCRIPTION
This PR combines OSW-553 and OSW-554. It issues a command to set AMEBA mode to OFF daily and when the CSC changes state to DISABLED.

It might also be appropriate to change the behavior of the CSC so that the connection is made when the CSC moves to DISABLED instead of when it moves to ENABLED.