### PR TITLE
OSW-1397: Refine handling of DIMM events

### DIFF
--- a/doc/news/OSW-1397.feature.rst
+++ b/doc/news/OSW-1397.feature.rst
@@ -1,0 +1,1 @@
+Refined handling of DIMM events.

--- a/python/lsst/ts/dimm/controllers/astelco_dimm.py
+++ b/python/lsst/ts/dimm/controllers/astelco_dimm.py
@@ -484,3 +484,8 @@ definitions:
         running_master_commands = len(self.master.running_commands)
         running_meteo_commands = len(self.meteo.running_commands)
         return running_master_commands + running_meteo_commands
+
+    async def unset(self):
+        """Disconnect the TCP connections."""
+        await self.master.unset()
+        await self.meteo.unset()

--- a/python/lsst/ts/dimm/controllers/open_tpl_connection.py
+++ b/python/lsst/ts/dimm/controllers/open_tpl_connection.py
@@ -236,7 +236,6 @@ class OpenTplConnection:
 
     async def unset(self) -> None:
         await self.disconnect()
-        await super().unset()
 
     async def start(self):
         """Start DIMM. Overwrites method from base class."""
@@ -383,15 +382,15 @@ class OpenTplConnection:
                         command = self.running_commands.get(cmdid)
                         if command is not None:
                             command.replies.append(reply)
-                            try:
-                                handler(command=command, cmdid=cmdid, **kwargs)
-                            except Exception:
-                                self.log.exception(
-                                    f"Reply handler {handler} failed on {reply!r}"
-                                )
-                            if command.done_task.done():
-                                self.running_commands.pop(cmdid)
-                            break
+                        try:
+                            handler(command=command, cmdid=cmdid, **kwargs)
+                        except Exception:
+                            self.log.exception(
+                                f"Reply handler {handler} failed on {reply!r}"
+                            )
+                        if command is not None and command.done_task.done():
+                            self.running_commands.pop(cmdid)
+                        break
                 else:
                     self.log.warning(f"Ignoring unrecognized reply {reply!r}")
 
@@ -420,7 +419,7 @@ class OpenTplConnection:
         Parameters
         ----------
         command : `AstelcoCommand`
-            The command. Must not be None.
+            The command.
         cmdid : `int`
             The command ID.
         state : `str`
@@ -442,7 +441,7 @@ class OpenTplConnection:
                     command.done_task.set_result(None)
                 else:
                     self.log.warning(
-                        f"Cannot set {command} to error; it already finished"
+                        f"Cannot set {command} to complete; it already finished"
                     )
 
     def handle_data_error(self, command, cmdid, name, error):
@@ -454,7 +453,7 @@ class OpenTplConnection:
         Parameters
         ----------
         command : `AstelcoCommand`
-            The command. Must not be None.
+            The command.
         cmdid : `int`
             The command ID.
         name : `str`
@@ -489,7 +488,7 @@ class OpenTplConnection:
         Parameters
         ----------
         command : `AstelcoCommand`
-            The command. Must not be None.
+            The command.
         cmdid : `int`
             The command ID.
         name : `str`
@@ -521,7 +520,7 @@ class OpenTplConnection:
         Parameters
         ----------
         command : `AstelcoCommand`
-            The command. Must not be None.
+            The command.
         cmdid : `int`
             The command ID.
         name : `str`
@@ -533,7 +532,8 @@ class OpenTplConnection:
     def handle_event(self, command, cmdid, event_type, name, number, description=""):
         """Handle an EVENT reply.
 
-        We aren't relying on events, so just log it for now.
+        We aren't relying on events, so just log it for now (if WARN or
+        higher).
 
         Parameters
         ----------
@@ -550,7 +550,23 @@ class OpenTplConnection:
         description : `str`, optional
             More information.
         """
-        self.log.info(f"Read event {event_type} {name}={number} {description}")
+        # Ignore DEBUG and INFO events to avoid overwhelming the EFD logs.
+        if event_type in ("DEBUG", "INFO"):
+            return
+
+        log_str = (
+            f"DIMM log: [{command.name} {command.arg}] "
+            if command is not None
+            else f"DIMM log: [{cmdid=}] " if cmdid != 0 else "DIMM log: "
+        )
+
+        log_str += f"{name}:{number} {description}"
+        if event_type == "WARN":
+            self.log.warning(log_str)
+        elif event_type == "ERROR":
+            self.log.error(log_str)
+        else:
+            self.log.error(f"Event has unknown type {event_type} - {log_str}")
 
     @property
     def connected(self):

--- a/python/lsst/ts/dimm/dimm_csc.py
+++ b/python/lsst/ts/dimm/dimm_csc.py
@@ -144,7 +144,8 @@ class DIMMCSC(salobj.ConfigurableCsc):
     async def close_tasks(self) -> None:
         """Stop active tasks."""
         if self.controller is not None:
-            self.controller.unset_controller()
+            await self.controller.unset()
+            self.controller = None
         await super().close_tasks()
 
     async def configure(self, config):

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -23,7 +23,8 @@ import asyncio
 import datetime
 import pathlib
 import unittest
-from unittest.mock import AsyncMock, patch
+from itertools import chain
+from unittest.mock import AsyncMock, call, patch
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -194,8 +195,9 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
         )
         long_sleeps.clear()
 
-        with patch("datetime.datetime", FixedDateTime), patch(
-            "asyncio.sleep", new=capped_sleep
+        with (
+            patch("datetime.datetime", FixedDateTime),
+            patch("asyncio.sleep", new=capped_sleep),
         ):
             async with self.make_csc(
                 initial_state=salobj.State.ENABLED,
@@ -235,8 +237,9 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
         )
         long_sleeps.clear()
 
-        with patch("datetime.datetime", FixedDateTime), patch(
-            "asyncio.sleep", new=capped_sleep
+        with (
+            patch("datetime.datetime", FixedDateTime),
+            patch("asyncio.sleep", new=capped_sleep),
         ):
             async with self.make_csc(
                 initial_state=salobj.State.ENABLED,
@@ -305,3 +308,44 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             set_automation_mode.assert_awaited_with(
                 dimm.controllers.base_dimm.AutomationMode.OFF
             )
+
+    async def test_astelco_dimm_events(self):
+        async with self.make_csc(
+            initial_state=salobj.State.ENABLED,
+            config_dir=TEST_CONFIG_DIR,
+            simulation_mode=1,
+        ):
+            with (
+                patch.object(self.csc.controller.master.log, "debug") as mock_debug,
+                patch.object(self.csc.controller.master.log, "info") as mock_info,
+                patch.object(self.csc.controller.master.log, "warning") as mock_warn,
+                patch.object(self.csc.controller.master.log, "error") as mock_error,
+            ):
+                info_message = "0 EVENT INFO SAMPLE:0 Sample info message"
+                warn_message = "0 EVENT WARN SAMPLE:0 Sample warning message"
+                error_message = "12345 EVENT ERROR SAMPLE:0 Sample error message"
+
+                for message in (info_message, warn_message, error_message):
+                    await self.csc.controller.mock_master_port.write_msg(message)
+
+                await asyncio.sleep(SHORT_TIMEOUT)
+
+                for call_args_list in chain(
+                    mock_debug.call_args_list,
+                    mock_info.call_args_list,
+                    mock_warn.call_args_list,
+                    mock_error.call_args_list,
+                ):
+                    assert (
+                        call("DIMM log: SAMPLE:0 Sample info message")
+                        not in call_args_list
+                    )
+
+                assert (
+                    call("DIMM log: SAMPLE:0 Sample warning message")
+                    in mock_warn.call_args_list
+                )
+                assert (
+                    call("DIMM log: [cmdid=12345] SAMPLE:0 Sample error message")
+                    in mock_error.call_args_list
+                )


### PR DESCRIPTION
There's a bug in the handling of events from DIMM. This PR fixes that bug and refines the event handler a bit. In particular, INFO and DEBUG events are dropped, since the information in those events is redundant with data obtained for telemetry.

Additionally, I ran across a bug in the cleanup code while working on this change. This PR also addresses that bug, which affects the `unset` class methods.