### PR TITLE
OSW-1967: make dimm CSC change state when turning itself off in morning

### DIFF
--- a/doc/news/OSW-1967.feature
+++ b/doc/news/OSW-1967.feature
@@ -1,0 +1,1 @@
+Make CSC change state when turning itself off in the morning if in ENABLED state.

--- a/python/lsst/ts/dimm/dimm_csc.py
+++ b/python/lsst/ts/dimm/dimm_csc.py
@@ -27,6 +27,8 @@ from zoneinfo import ZoneInfo
 
 from lsst.ts import salobj, utils
 from lsst.ts.dimm import controllers
+from lsst.ts.xml.sal_enums import State
+from lsst.ts.xml.type_hints import BaseMsgType
 
 from . import __version__
 from .config_schema import CONFIG_SCHEMA
@@ -458,6 +460,9 @@ class DIMMCSC(salobj.ConfigurableCsc):
 
             # Send the command
             await self.controller.set_automation_mode(AutomationMode.OFF)
+            if self.summary_state == State.ENABLED:
+                # Do state transition if this happened in enabled state
+                await self.do_disable(BaseMsgType())
 
             # Make sure we aren't going to get a sleep of zero on the
             # next run through the loop.

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -243,26 +243,20 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             ):
                 self.csc.controller.set_automation_mode = AsyncMock()
 
-                await real_sleep(10)
-                self.assertEqual(long_sleeps, [60])
-                self.csc.controller.set_automation_mode.assert_awaited_with(
-                    dimm.controllers.base_dimm.AutomationMode.OFF
-                )
-
-                self.remote.evt_summaryState.flush()
-                await salobj.set_summary_state(
+                await self.assert_next_summary_state(
+                    state=salobj.State.ENABLED,
+                    flush=False,
                     remote=self.remote,
-                    state=salobj.State.STANDBY,
                 )
                 await self.assert_next_summary_state(
                     state=salobj.State.DISABLED,
                     flush=False,
                     remote=self.remote,
                 )
-                await self.assert_next_summary_state(
-                    state=salobj.State.STANDBY,
-                    flush=False,
-                    remote=self.remote,
+
+                self.assertEqual(long_sleeps, [60])
+                self.csc.controller.set_automation_mode.assert_awaited_with(
+                    dimm.controllers.base_dimm.AutomationMode.OFF
                 )
 
     async def test_ameba_off_tomorrow(self):
@@ -285,26 +279,20 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             ):
                 self.csc.controller.set_automation_mode = AsyncMock()
 
-                await real_sleep(10)
-                self.assertEqual(long_sleeps, [86400 - 60])
-                self.csc.controller.set_automation_mode.assert_awaited_with(
-                    dimm.controllers.base_dimm.AutomationMode.OFF
-                )
-
-                self.remote.evt_summaryState.flush()
-                await salobj.set_summary_state(
+                await self.assert_next_summary_state(
+                    state=salobj.State.ENABLED,
+                    flush=False,
                     remote=self.remote,
-                    state=salobj.State.STANDBY,
                 )
                 await self.assert_next_summary_state(
                     state=salobj.State.DISABLED,
                     flush=False,
                     remote=self.remote,
                 )
-                await self.assert_next_summary_state(
-                    state=salobj.State.STANDBY,
-                    flush=False,
-                    remote=self.remote,
+
+                self.assertEqual(long_sleeps, [86400 - 60])
+                self.csc.controller.set_automation_mode.assert_awaited_with(
+                    dimm.controllers.base_dimm.AutomationMode.OFF
                 )
 
     async def test_ameba_off_on_disable(self):


### PR DESCRIPTION
Since the main difference between disabled and enabled is if automation mode is on, we change state to disabled if the day time switch happens in the morning.